### PR TITLE
Add per interface filtering options for net collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-ENV=GOOS=linux GOARCH=amd64
 BUILD_DIR=build
 CC=go build
 GITHASH=$(shell git rev-parse HEAD)
@@ -11,11 +10,11 @@ VPATH= $(BUILD_DIR)
 .SECONDEXPANSION:
 
 build: noderig.go $$(call rwildcard, ./cmd, *.go) $$(call rwildcard, ./collectors, *.go)
-	$(ENV) $(CC) $(DFLAGS) $(CFLAGS) -o $(BUILD_DIR)/noderig noderig.go
+	$(CC) $(DFLAGS) $(CFLAGS) -o $(BUILD_DIR)/noderig noderig.go
 
 .PHONY: release
 release: noderig.go $$(call rwildcard, ./cmd, *.go) $$(call rwildcard, ./collectors, *.go)
-	$(ENV) $(CC) $(CFLAGS) -o $(BUILD_DIR)/noderig noderig.go
+	$(CC) $(CFLAGS) -o $(BUILD_DIR)/noderig noderig.go
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
+ENV=GOOS=linux GOARCH=amd64
 BUILD_DIR=build
-
 CC=go build
 GITHASH=$(shell git rev-parse HEAD)
 DFLAGS=-race
@@ -11,11 +11,11 @@ VPATH= $(BUILD_DIR)
 .SECONDEXPANSION:
 
 build: noderig.go $$(call rwildcard, ./cmd, *.go) $$(call rwildcard, ./collectors, *.go)
-	$(CC) $(DFLAGS) $(CFLAGS) -o $(BUILD_DIR)/noderig noderig.go
+	$(ENV) $(CC) $(DFLAGS) $(CFLAGS) -o $(BUILD_DIR)/noderig noderig.go
 
 .PHONY: release
 release: noderig.go $$(call rwildcard, ./cmd, *.go) $$(call rwildcard, ./collectors, *.go)
-	$(CC) $(CFLAGS) -o $(BUILD_DIR)/noderig noderig.go
+	$(ENV) $(CC) $(CFLAGS) -o $(BUILD_DIR)/noderig noderig.go
 
 .PHONY: lint
 lint:

--- a/Readme.md
+++ b/Readme.md
@@ -143,6 +143,18 @@ listen: none             # Listen address, set to none to disable http endpoint 
 collectors: /opt/noderig # Custom collectors directory                          (Optional, default: none)
 ```
 
+
+#### Collectors Options
+
+Some collectors can accept optional parameters.
+
+```yaml
+net-opts: 
+  interfaces:            # Give a filtering list of interfaces for which you want metrics
+    - eth0
+    - eth1
+```
+
 ## Sample metrics
 
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,10 +7,11 @@ import (
 	"strconv"
 	"time"
 
+	"net/http"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"net/http"
 
 	"github.com/runabove/noderig/collectors"
 	"github.com/runabove/noderig/core"
@@ -94,7 +95,7 @@ var RootCmd = &cobra.Command{
 		load := collectors.NewLoad(uint(viper.GetInt("period")), uint8(viper.GetInt("load")))
 		cs = append(cs, load)
 
-		net := collectors.NewNet(uint(viper.GetInt("period")), uint8(viper.GetInt("net")))
+		net := collectors.NewNet(uint(viper.GetInt("period")), uint8(viper.GetInt("net")), viper.Get("net-opts"))
 		cs = append(cs, net)
 
 		disk := collectors.NewDisk(uint(viper.GetInt("period")), uint8(viper.GetInt("disk")))

--- a/collectors/net.go
+++ b/collectors/net.go
@@ -3,7 +3,6 @@ package collectors
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -24,19 +23,19 @@ type Net struct {
 // NewNet returns an initialized Net collector.
 func NewNet(period uint, level uint8, opts interface{}) *Net {
 
-	var options map[string]interface{}
 	var ifaces []string
 
 	if opts != nil {
-		options = opts.(map[string]interface{})
-		if val, ok := options["interfaces"]; ok {
-			if reflect.TypeOf(val).Kind() == reflect.Slice {
-				ifs := val.([]interface{})
-				for _, v := range ifs {
-					ifaces = append(ifaces, v.(string))
+		if options, ok := opts.(map[string]interface{}); ok {
+			if val, ok := options["interfaces"]; ok {
+				if ifs, ok := val.([]interface{}); ok {
+					for _, v := range ifs {
+						if s, ok := v.(string); ok {
+							ifaces = append(ifaces, s)
+						}
+					}
 				}
 			}
-
 		}
 
 	}

--- a/collectors/net.go
+++ b/collectors/net.go
@@ -12,19 +12,35 @@ import (
 
 // Net collects network related metrics
 type Net struct {
-	counters []net.IOCountersStat
-
-	mutex     sync.RWMutex
-	sensision bytes.Buffer
-	level     uint8
-	period    uint
+	counters   []net.IOCountersStat
+	interfaces []string
+	mutex      sync.RWMutex
+	sensision  bytes.Buffer
+	level      uint8
+	period     uint
 }
 
 // NewNet returns an initialized Net collector.
-func NewNet(period uint, level uint8) *Net {
+func NewNet(period uint, level uint8, opts interface{}) *Net {
+
+	var options map[string]interface{}
+	var ifaces []string
+
+	if opts != nil {
+		options = opts.(map[string]interface{})
+		if val, ok := options["interfaces"]; ok {
+			ifs := val.([]interface{})
+			for _, v := range ifs {
+				ifaces = append(ifaces, v.(string))
+			}
+		}
+
+	}
+
 	c := &Net{
-		level:  level,
-		period: period,
+		level:      level,
+		period:     period,
+		interfaces: ifaces,
 	}
 
 	if level == 0 {
@@ -68,6 +84,8 @@ func (c *Net) scrape() error {
 	for i, cnt := range counters {
 		if cnt.Name == "lo" {
 			continue
+		} else if c.interfaces != nil && !stringInSlice(cnt.Name, c.interfaces) {
+			continue
 		}
 		in += cnt.BytesRecv - c.counters[i].BytesRecv
 		out += cnt.BytesSent - c.counters[i].BytesSent
@@ -83,7 +101,7 @@ func (c *Net) scrape() error {
 
 	now := fmt.Sprintf("%v//", time.Now().UnixNano()/1000)
 
-  if c.level == 1 {
+	if c.level == 1 {
 		gts := fmt.Sprintf("%v os.net.bytes{direction=in} %v\n", now, in)
 		c.sensision.WriteString(gts)
 
@@ -95,11 +113,13 @@ func (c *Net) scrape() error {
 		for i, cnt := range counters {
 			if cnt.Name == "lo" {
 				continue
+			} else if c.interfaces != nil && !stringInSlice(cnt.Name, c.interfaces) {
+				continue
 			}
-			gts := fmt.Sprintf("%v os.net.bytes{iface=%v,direction=in} %v\n", now, cnt.Name, (cnt.BytesRecv - c.counters[i].BytesRecv) / uint64(c.period/1000))
+			gts := fmt.Sprintf("%v os.net.bytes{iface=%v,direction=in} %v\n", now, cnt.Name, (cnt.BytesRecv-c.counters[i].BytesRecv)/uint64(c.period/1000))
 			c.sensision.WriteString(gts)
 
-			gts = fmt.Sprintf("%v os.net.bytes{iface=%v,direction=out} %v\n", now, cnt.Name, (cnt.BytesSent - c.counters[i].BytesSent) / uint64(c.period/1000))
+			gts = fmt.Sprintf("%v os.net.bytes{iface=%v,direction=out} %v\n", now, cnt.Name, (cnt.BytesSent-c.counters[i].BytesSent)/uint64(c.period/1000))
 			c.sensision.WriteString(gts)
 		}
 	}
@@ -108,23 +128,25 @@ func (c *Net) scrape() error {
 		for i, cnt := range counters {
 			if cnt.Name == "lo" {
 				continue
+			} else if c.interfaces != nil && !stringInSlice(cnt.Name, c.interfaces) {
+				continue
 			}
-			gts := fmt.Sprintf("%v os.net.packets{iface=%v,direction=in} %v\n", now, cnt.Name, (cnt.PacketsRecv - c.counters[i].PacketsRecv) / uint64(c.period/1000))
+			gts := fmt.Sprintf("%v os.net.packets{iface=%v,direction=in} %v\n", now, cnt.Name, (cnt.PacketsRecv-c.counters[i].PacketsRecv)/uint64(c.period/1000))
 			c.sensision.WriteString(gts)
 
-			gts = fmt.Sprintf("%v os.net.packets{iface=%v,direction=out} %v\n", now, cnt.Name, (cnt.PacketsSent - c.counters[i].PacketsSent) / uint64(c.period/1000))
+			gts = fmt.Sprintf("%v os.net.packets{iface=%v,direction=out} %v\n", now, cnt.Name, (cnt.PacketsSent-c.counters[i].PacketsSent)/uint64(c.period/1000))
 			c.sensision.WriteString(gts)
 
-			gts = fmt.Sprintf("%v os.net.errs{iface=%v,direction=in} %v\n", now, cnt.Name, (cnt.Errin - c.counters[i].Errin) / uint64(c.period/1000))
+			gts = fmt.Sprintf("%v os.net.errs{iface=%v,direction=in} %v\n", now, cnt.Name, (cnt.Errin-c.counters[i].Errin)/uint64(c.period/1000))
 			c.sensision.WriteString(gts)
 
-			gts = fmt.Sprintf("%v os.net.errs{iface=%v,direction=out} %v\n", now, cnt.Name, (cnt.Errout - c.counters[i].Errout) / uint64(c.period/1000))
+			gts = fmt.Sprintf("%v os.net.errs{iface=%v,direction=out} %v\n", now, cnt.Name, (cnt.Errout-c.counters[i].Errout)/uint64(c.period/1000))
 			c.sensision.WriteString(gts)
 
-			gts = fmt.Sprintf("%v os.net.dropped{iface=%v,direction=in} %v\n", now, cnt.Name, (cnt.Dropin - c.counters[i].Dropin) / uint64(c.period/1000))
+			gts = fmt.Sprintf("%v os.net.dropped{iface=%v,direction=in} %v\n", now, cnt.Name, (cnt.Dropin-c.counters[i].Dropin)/uint64(c.period/1000))
 			c.sensision.WriteString(gts)
 
-			gts = fmt.Sprintf("%v os.net.dropped{iface=%v,direction=out} %v\n", now, cnt.Name, (cnt.Dropout - c.counters[i].Dropout) / uint64(c.period/1000))
+			gts = fmt.Sprintf("%v os.net.dropped{iface=%v,direction=out} %v\n", now, cnt.Name, (cnt.Dropout-c.counters[i].Dropout)/uint64(c.period/1000))
 			c.sensision.WriteString(gts)
 		}
 	}
@@ -132,4 +154,13 @@ func (c *Net) scrape() error {
 	c.counters = counters
 
 	return nil
+}
+
+func stringInSlice(str string, list []string) bool {
+	for _, v := range list {
+		if v == str {
+			return true
+		}
+	}
+	return false
 }

--- a/collectors/net.go
+++ b/collectors/net.go
@@ -3,6 +3,7 @@ package collectors
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -29,10 +30,13 @@ func NewNet(period uint, level uint8, opts interface{}) *Net {
 	if opts != nil {
 		options = opts.(map[string]interface{})
 		if val, ok := options["interfaces"]; ok {
-			ifs := val.([]interface{})
-			for _, v := range ifs {
-				ifaces = append(ifaces, v.(string))
+			if reflect.TypeOf(val).Kind() == reflect.Slice {
+				ifs := val.([]interface{})
+				for _, v := range ifs {
+					ifaces = append(ifaces, v.(string))
+				}
 			}
+
 		}
 
 	}


### PR DESCRIPTION
We may need to filter interfaces so that we don't push metrics for internals networking interfaces (dummy, bond, ifb, p2p, bridg, ip6tnl, ... ).

It it accomplished by providing optionals parameters to a collector module : 
`
net-opts:
  interfaces:
    - eth0
    - eth1
`

