### PR TITLE
Allow customization of BUILD_DIR from command line.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD_DIR=build
+BUILD_DIR=${build_dir}/build
 CC=go build
 GITHASH=$(shell git rev-parse HEAD)
 DFLAGS=-race
@@ -35,7 +35,7 @@ dev: format lint build
 
 .PHONY: clean
 clean:
-	-rm -r build
+	rm -rf ${build_dir}/build
 
 # Docker build
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD_DIR=${build_dir}/build
+BUILD_DIR=build
 CC=go build
 GITHASH=$(shell git rev-parse HEAD)
 DFLAGS=-race
@@ -35,7 +35,7 @@ dev: format lint build
 
 .PHONY: clean
 clean:
-	rm -rf ${build_dir}/build
+	rm -rf $BUILD_DIR
 
 # Docker build
 


### PR DESCRIPTION
This is needed to set the destination of objects when building a debian
package (typically <curdir>/debian/tmp).